### PR TITLE
Switched to https for maven repos

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -44,7 +44,7 @@
 
         <repository>
             <id>public-central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -55,7 +55,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
Since the beginning of the year, http connections to the central maven repos are not accepted anymore. 
https://blog.sonatype.com/central-repository-moving-to-https